### PR TITLE
Update guava to 29.0-jre

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ repositories {
 }
 
 dependencies {
-    compile 'com.google.guava:guava:23.0'
+    compile 'com.google.guava:guava:29.0-jre'
     testCompile 'junit:junit:4.12'
 }
 


### PR DESCRIPTION
Fixes vulnerability described in https://github.com/google/guava/wiki/CVE-2018-10237