### PR TITLE
Ignore synthetic fields on complex parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v0.4.2
+
+- Ignore synthetic fields on complex parameters
+
 ## v0.4.1
 
 - Add support to complex parameters

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ GraphQL query builder for Java
     <dependency>
         <groupId>com.github.k0kubun</groupId>
         <artifactId>graphql-query-builder</artifactId>
-        <version>0.4.1</version>
+        <version>0.4.2</version>
     </dependency>
 </dependencies>
 ```
@@ -20,7 +20,7 @@ GraphQL query builder for Java
 
 ```groovy
 dependencies {
-    compile 'com.github.k0kubun:graphql-query-builder:0.4.1'
+    compile 'com.github.k0kubun:graphql-query-builder:0.4.2'
 }
 ```
 

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ apply plugin: 'signing'
 
 group 'com.github.k0kubun'
 archivesBaseName = 'graphql-query-builder'
-version = '0.4.1'
+version = '0.4.2'
 description = 'GraphQL query builder for Java'
 
 repositories {

--- a/src/main/java/com/github/k0kubun/builder/query/graphql/model/GraphQLObject.java
+++ b/src/main/java/com/github/k0kubun/builder/query/graphql/model/GraphQLObject.java
@@ -108,6 +108,10 @@ public class GraphQLObject
 
         for (Field classField : fields)
         {
+            if (classField.isSynthetic()) {
+                continue;
+            }
+
             classField.setAccessible(true);
             Object value;
 

--- a/src/test/java/com/github/k0kubun/builder/query/graphql/example/ParamExample.java
+++ b/src/test/java/com/github/k0kubun/builder/query/graphql/example/ParamExample.java
@@ -6,6 +6,7 @@ public class ParamExample implements GraphQLParam {
     private String userId;
     private Integer from;
     private FilterExample filter;
+    private Synthetic synthetic = new Synthetic();
 
     public void setFrom(Integer from) {
         this.from = from;
@@ -19,4 +20,5 @@ public class ParamExample implements GraphQLParam {
         this.filter = filter;
     }
 
+    class Synthetic {}
 }


### PR DESCRIPTION
When an enclosing class accesses a private attribute of a nested class, Java compiler creates synthetic method for that attribute. [More info](https://javapapers.com/core-java/java-synthetic-class-method-field/).

As some libraries and the Java compiler creates synthetic members in certain situations, a validation was added to avoid including these fields as query parameters.

In particular, I found this because Jacoco adds a synthetic private static field ($jacocoData) which is included to collect execution data. [Related issue](https://github.com/jacoco/jacoco/issues/168).